### PR TITLE
Add an on-update parameter.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,14 @@ inputs:
   prefix:
     description: comment prefix
     required: true
+  on-update:
+    description: control behavior on update can be append or replace (default append)
+    required: false
+    default: append
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.path }}
     - ${{ inputs.prefix }}
+    - ${{ inputs.replace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ else
 end
 file_path = ARGV[0]
 prefix = ARGV[1]
+on_update = ARGV[2]
 
 puts Dir.entries(".")
 
@@ -48,5 +49,13 @@ if com == nil
   github.add_comment(repo, pr_number, prefix + "\n\n" + message)
 else
   cur_time = Time.new
-  com = github.update_comment(repo, com["id"], com["body"] + "\n\nUpdate on " + cur_time.inspect + "\n\n" + message)
+  timestamp = "\n\nUpdate on " + cur_time.inspect + "\n\n"
+
+  if on_update == "replace"
+    body = prefix + timestamp + message
+  else
+    body = com["body"] + timestamp + message
+  end
+
+  com = github.update_comment(repo, com["id"], body)
 end


### PR DESCRIPTION
Hey, this is super useful, thanks for creating the action. This PR adds an on-update parameter that allows users to control the behavior when updating comments. Setting it to "replace" will cause the body to be replaced rather than appended indefinitely.